### PR TITLE
Polishing22

### DIFF
--- a/Sources/RedBlackTreeModule/_Tree/___Tree.swift
+++ b/Sources/RedBlackTreeModule/_Tree/___Tree.swift
@@ -279,10 +279,11 @@ extension ___Tree {
   @inline(__always)
   internal func ___popDetroy() -> _NodePtr {
     assert(_header.destroyCount > 0)
-    let p = _header.destroyNode
-    _header.destroyNode = __node_ptr[p].__left_
-    _header.destroyCount -= 1
-    return p
+    defer {
+      _header.destroyNode = __node_ptr[_header.destroyNode].__left_
+      _header.destroyCount -= 1
+    }
+    return _header.destroyNode
   }
   /// O(1)
   @nonobjc

--- a/Sources/RedBlackTreeModule/_Tree/___Tree.swift
+++ b/Sources/RedBlackTreeModule/_Tree/___Tree.swift
@@ -269,7 +269,7 @@ extension ___Tree {
     assert(_header.destroyCount <= _header.capacity)
     assert(_header.destroyNode != p)
     __node_ptr[p].__left_ = _header.destroyNode
-    __node_ptr[p].__right_ = p
+    __node_ptr[p].__right_ = .nullptr
     __node_ptr[p].__parent_ = .nullptr
     __node_ptr[p].__is_black_ = false
     _header.destroyNode = p
@@ -281,7 +281,7 @@ extension ___Tree {
   @inline(__always)
   internal func ___popDetroy() -> _NodePtr {
     assert(_header.destroyCount > 0)
-    let p = __node_ptr[_header.destroyNode].__right_
+    let p = _header.destroyNode
     _header.destroyNode = __node_ptr[p].__left_
     _header.destroyCount -= 1
     return p

--- a/Sources/RedBlackTreeModule/_Tree/___Tree.swift
+++ b/Sources/RedBlackTreeModule/_Tree/___Tree.swift
@@ -269,9 +269,7 @@ extension ___Tree {
     assert(_header.destroyCount <= _header.capacity)
     assert(_header.destroyNode != p)
     __node_ptr[p].__left_ = _header.destroyNode
-    __node_ptr[p].__right_ = .nullptr
     __node_ptr[p].__parent_ = .nullptr
-    __node_ptr[p].__is_black_ = false
     _header.destroyNode = p
     _header.destroyCount += 1
   }

--- a/Sources/RedBlackTreeModule/_Tree/___Tree.swift
+++ b/Sources/RedBlackTreeModule/_Tree/___Tree.swift
@@ -283,6 +283,7 @@ extension ___Tree {
       _header.destroyNode = __node_ptr[_header.destroyNode].__left_
       _header.destroyCount -= 1
     }
+    __node_ptr[_header.destroyNode].__is_black_ = false
     return _header.destroyNode
   }
   /// O(1)


### PR DESCRIPTION
削除済みノードの管理を双方向リンクリストから片方向リンクリストに変更